### PR TITLE
fix: resolve DoS for zero-intolerant tokens in approveAndBridge (Fixes #5)

### DIFF
--- a/src/mixin/ApproveAndBridge.sol
+++ b/src/mixin/ApproveAndBridge.sol
@@ -23,6 +23,7 @@ abstract contract ApproveAndBridge is IApproveAndBridge {
     function approveAndBridge(IERC20 token, uint256 minAmount, uint256 nativeTokenExtraFee, bytes calldata data)
         external
     {
+        address target = bridgeApprovalTarget();
         // get the balance of the token
         uint256 balance = address(token) == NATIVE_TOKEN_ADDRESS
             // if native token, reduce the extra fee from balance
@@ -35,11 +36,31 @@ abstract contract ApproveAndBridge is IApproveAndBridge {
 
         // approve the bridgeApprovalTarget if ERC20
         if (address(token) != NATIVE_TOKEN_ADDRESS) {
-            token.forceApprove(bridgeApprovalTarget(), balance);
+            uint256 current = token.allowance(address(this), target);
+            if (current < balance) {
+                // Try direct approval first to bypass zero-intolerant reverts
+                (bool success, ) = address(token).call(
+                    abi.encodeWithSelector(IERC20.approve.selector, target, balance)
+                );
+
+                // Fallback to forceApprove if direct fails (e.g. USDT)
+                if (!success) {
+                    token.forceApprove(target, balance);
+                }
+            }
         }
 
         // bridge the token
         bridge(token, balance, nativeTokenExtraFee, data);
+
+        // POST-BRIDGE: Conditional Silent Cleanup
+        if (address(token) != NATIVE_TOKEN_ADDRESS) {
+            if (token.allowance(address(this), target) > 0) {
+                (bool success, ) = address(token).call(abi.encodeWithSelector(IERC20.approve.selector, target, 0));
+                success;
+            }
+            
+        }
     }
 
     /**

--- a/src/mixin/ApproveAndBridge.sol
+++ b/src/mixin/ApproveAndBridge.sol
@@ -39,12 +39,15 @@ abstract contract ApproveAndBridge is IApproveAndBridge {
             uint256 current = token.allowance(address(this), target);
             if (current < balance) {
                 // Try direct approval first to bypass zero-intolerant reverts
-                (bool success, ) = address(token).call(
+                (bool success, bytes memory returnData) = address(token).call(
                     abi.encodeWithSelector(IERC20.approve.selector, target, balance)
                 );
 
+                // Success if call didn't revert and (no return data or true boolean)
+                bool approved = success && (returnData.length == 0 || abi.decode(returnData, (bool)));
+
                 // Fallback to forceApprove if direct fails (e.g. USDT)
-                if (!success) {
+                if (!approved) {
                     token.forceApprove(target, balance);
                 }
             }


### PR DESCRIPTION

#### **Summary**
Resolved a vulnerability where `ApproveAndBridge` could enter a permanent Denial of Service (DoS) state when interacting with "Zero-Intolerant" tokens that revert on `approve(0)`.

#### **The Issue**
When residual "dust" allowance exists, `SafeERC20.forceApprove` attempts a reset-to-zero before updating. Zero-intolerant tokens revert on this reset, blocking all future bridge attempts for that token.

#### **The Solution**
* **Sufficient Check:** Skips approval if existing dust covers the required balance.
* **Direct Attempt:** Uses a low-level `.call` to update allowance , bypassing the  revert.
* **Safe Fallback:** Falls back to `forceApprove` only if the direct call fails (e.g., for USDT).
* **Silent Cleanup:** Performs a post-bridge `approve(0)` via low-level call to ensure no settlement reverts even if the cleanup fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token approval reliability with a fallback path when standard approval fails.
  * Verified current allowances before applying approvals to avoid unnecessary transactions.
  * Added post-operation cleanup to reset token allowances after bridge transfers, reducing leftover permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->