### PR TITLE
feat: approve and bridge using across

### DIFF
--- a/src/AcrossApproveAndBridge.sol
+++ b/src/AcrossApproveAndBridge.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8;
+
+import {ApproveAndBridge, IERC20} from "./mixin/ApproveAndBridge.sol";
+import {IAcrossSpokePoolV3} from "./interface/IAcrossSpokePoolV3.sol";
+import {Math} from "./vendored/Math.sol";
+
+/// ! @dev UNAUDITED UNTESTED Do not use in production
+/// @dev Approves and deposits funds into an Across V3 SpokePool by calling
+///      `depositV3` with the provided calldata, after patching `inputAmount`
+///      and scaling `outputAmount` to the actual contract balance. This
+///      ensures any surplus from the upstream swap is honored by relayers.
+/// @dev `depositV3` has all static arguments before the trailing dynamic
+///      `message`, so `inputAmount` and `outputAmount` always live at fixed
+///      byte offsets within the calldata.
+contract AcrossApproveAndBridge is ApproveAndBridge {
+    error InvalidInput();
+    error BridgeFailed();
+
+    /// @dev `depositV3` selector length
+    uint8 private constant SELECTOR_LENGTH = 4;
+    /// @dev Byte offset (within calldata) of `inputAmount` — selector + 4 head slots
+    uint16 private constant INPUT_AMOUNT_OFFSET = SELECTOR_LENGTH + 4 * 32;
+    /// @dev Byte offset (within calldata) of `outputAmount` — selector + 5 head slots
+    uint16 private constant OUTPUT_AMOUNT_OFFSET = SELECTOR_LENGTH + 5 * 32;
+    /// @dev Minimum data length: selector + 11 static head slots + 1 offset slot for `message`
+    uint16 private constant MIN_DATA_LENGTH = SELECTOR_LENGTH + 12 * 32;
+
+    /// @dev Across V3 SpokePool address
+    address public immutable SPOKE_POOL;
+
+    constructor(address spokePool_) {
+        require(spokePool_.code.length > 0, "Spoke pool contract not deployed");
+
+        SPOKE_POOL = spokePool_;
+    }
+
+    /**
+     * @notice Approval should be given to the SpokePool address
+     * @dev Returns the SpokePool address
+     */
+    function bridgeApprovalTarget() public view override returns (address) {
+        return SPOKE_POOL;
+    }
+
+    /**
+     * @notice Deposit into the Across V3 SpokePool.
+     * @dev Patches the `inputAmount` and `outputAmount` fields in the encoded
+     *      `depositV3` calldata, then forwards the call to the SpokePool.
+     * @param token The token to bridge. Use `NATIVE_TOKEN_ADDRESS` to bridge the native asset.
+     * @param amount The actual amount of `token` held by this contract.
+     * @param nativeTokenExtraFee Extra value forwarded with the call on top of the bridged amount.
+     * @param data Encoded `depositV3` calldata. Must select `depositV3(address,address,address,address,uint256,uint256,uint256,address,uint32,uint32,uint32,bytes)`.
+     */
+    function bridge(IERC20 token, uint256 amount, uint256 nativeTokenExtraFee, bytes calldata data) internal override {
+        bytes memory modifiedCalldata = _patchAmounts(amount, data);
+
+        uint256 callValue = address(token) == NATIVE_TOKEN_ADDRESS ? amount + nativeTokenExtraFee : nativeTokenExtraFee;
+
+        (bool success,) = SPOKE_POOL.call{value: callValue}(modifiedCalldata);
+        if (!success) revert BridgeFailed();
+    }
+
+    /**
+     * @dev Reads the original `inputAmount` and `outputAmount` from the
+     *      depositV3 calldata, replaces `inputAmount` with `amount`, and
+     *      scales `outputAmount` proportionally.
+     */
+    function _patchAmounts(uint256 amount, bytes calldata data) internal pure returns (bytes memory) {
+        if (data.length < MIN_DATA_LENGTH) revert InvalidInput();
+        if (bytes4(data[:SELECTOR_LENGTH]) != IAcrossSpokePoolV3.depositV3.selector) revert InvalidInput();
+
+        bytes memory modified = data;
+
+        uint256 originalInput = _readUint256(modified, INPUT_AMOUNT_OFFSET);
+        if (originalInput == 0) revert InvalidInput();
+
+        uint256 originalOutput = _readUint256(modified, OUTPUT_AMOUNT_OFFSET);
+        uint256 newOutput = Math.mulDiv({x: originalOutput, y: amount, denominator: originalInput});
+
+        _writeUint256(modified, INPUT_AMOUNT_OFFSET, amount);
+        _writeUint256(modified, OUTPUT_AMOUNT_OFFSET, newOutput);
+
+        return modified;
+    }
+
+    /// @dev Reads a uint256 at a given byte index in a bytes array
+    function _readUint256(bytes memory _data, uint256 _index) internal pure returns (uint256 value) {
+        assembly {
+            value := mload(add(add(_data, 0x20), _index))
+        }
+    }
+
+    /// @dev Writes a uint256 at a given byte index in a bytes array, in place.
+    function _writeUint256(bytes memory _data, uint256 _index, uint256 _amount) internal pure {
+        assembly {
+            mstore(add(add(_data, 0x20), _index), _amount)
+        }
+    }
+}

--- a/src/interface/IAcrossSpokePoolV3.sol
+++ b/src/interface/IAcrossSpokePoolV3.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8;
+
+/// @dev Minimal interface for the Across V3 SpokePool. See:
+/// https://github.com/across-protocol/contracts/blob/master/contracts/interfaces/V3SpokePoolInterface.sol
+interface IAcrossSpokePoolV3 {
+    /// @notice Deposit funds into the SpokePool to be bridged to the destination chain.
+    /// @dev When `inputToken` is the wrapped native token, ETH may be sent via `msg.value`
+    ///      equal to `inputAmount` and the SpokePool will wrap it internally.
+    function depositV3(
+        address depositor,
+        address recipient,
+        address inputToken,
+        address outputToken,
+        uint256 inputAmount,
+        uint256 outputAmount,
+        uint256 destinationChainId,
+        address exclusiveRelayer,
+        uint32 quoteTimestamp,
+        uint32 fillDeadline,
+        uint32 exclusivityDeadline,
+        bytes calldata message
+    ) external payable;
+}

--- a/test/AcrossApproveAndBridge.t.sol
+++ b/test/AcrossApproveAndBridge.t.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IERC20} from "../src/vendored/IERC20.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockFailingBridge} from "./mocks/MockBridge.sol";
+import {MockAcrossSpokePool} from "./mocks/MockAcrossSpokePool.sol";
+
+import {AcrossApproveAndBridge, ApproveAndBridge} from "src/AcrossApproveAndBridge.sol";
+import {IAcrossSpokePoolV3} from "src/interface/IAcrossSpokePoolV3.sol";
+
+contract AcrossApproveAndBridgeTest is Test {
+    AcrossApproveAndBridge public acrossApproveAndBridge;
+    MockAcrossSpokePool public spokePool;
+    MockERC20 public mockToken;
+    MockFailingBridge public failingBridge;
+
+    address public constant NATIVE_TOKEN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    address public constant WETH = 0x4200000000000000000000000000000000000006;
+
+    address public depositor = makeAddr("depositor");
+    address public recipient = makeAddr("recipient");
+    address public outputToken = makeAddr("outputToken");
+
+    function setUp() public {
+        spokePool = new MockAcrossSpokePool();
+        acrossApproveAndBridge = new AcrossApproveAndBridge(address(spokePool));
+        mockToken = new MockERC20(0);
+        failingBridge = new MockFailingBridge();
+    }
+
+    /// @dev Builds a depositV3 calldata blob with the given input/output amounts.
+    /// @dev Built in chunks to avoid stack-too-deep when encoding 12 args.
+    function _buildDepositCalldata(address inputToken, uint256 inputAmount, uint256 outputAmount, bytes memory message)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes memory addrPart = abi.encode(depositor, recipient, inputToken, outputToken);
+        bytes memory amountsPart = abi.encode(inputAmount, outputAmount, uint256(42161), address(0));
+        // 11 fixed head slots + 1 offset slot for message = 12 slots = 384 bytes offset
+        bytes memory deadlinesPart = abi.encode(uint32(1700000000), uint32(1700003600), uint32(0), uint256(384));
+        bytes memory tail = abi.encode(message);
+        return abi.encodePacked(IAcrossSpokePoolV3.depositV3.selector, addrPart, amountsPart, deadlinesPart, tail);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+    function test_constructor() public view {
+        assertEq(acrossApproveAndBridge.SPOKE_POOL(), address(spokePool));
+    }
+
+    function test_constructor_shouldRevert_nonContractAddress() public {
+        address nonContract = address(0x123);
+        vm.expectRevert("Spoke pool contract not deployed");
+        new AcrossApproveAndBridge(nonContract);
+
+        address emptyContract = address(0x456);
+        vm.etch(emptyContract, "");
+        vm.expectRevert("Spoke pool contract not deployed");
+        new AcrossApproveAndBridge(emptyContract);
+    }
+
+    function test_bridgeApprovalTarget() public view {
+        assertEq(acrossApproveAndBridge.bridgeApprovalTarget(), address(spokePool));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          ERC20 BRIDGE FLOW
+    //////////////////////////////////////////////////////////////*/
+    function test_approveAndBridge_ERC20_exactBalance() public {
+        uint256 balance = 100e18;
+        mockToken.mint(address(acrossApproveAndBridge), balance);
+
+        bytes memory data = _buildDepositCalldata(address(mockToken), 100e18, 99e18, "");
+
+        vm.expectCall(address(mockToken), abi.encodeCall(IERC20.approve, (address(spokePool), balance)));
+        acrossApproveAndBridge.approveAndBridge(IERC20(mockToken), 50e18, 0, data);
+
+        assertEq(spokePool.callCount(), 1);
+        assertEq(spokePool.lastDepositor(), depositor);
+        assertEq(spokePool.lastRecipient(), recipient);
+        assertEq(spokePool.lastInputToken(), address(mockToken));
+        assertEq(spokePool.lastOutputToken(), outputToken);
+        assertEq(spokePool.lastInputAmount(), balance);
+        // exact balance == original input -> output unchanged
+        assertEq(spokePool.lastOutputAmount(), 99e18);
+        assertEq(spokePool.lastDestinationChainId(), 42161);
+        assertEq(spokePool.lastExclusiveRelayer(), address(0));
+        assertEq(spokePool.lastQuoteTimestamp(), 1700000000);
+        assertEq(spokePool.lastFillDeadline(), 1700003600);
+        assertEq(spokePool.lastExclusivityDeadline(), 0);
+        assertEq(spokePool.lastMessage(), hex"");
+        assertEq(spokePool.lastValue(), 0);
+    }
+
+    function test_approveAndBridge_ERC20_scalesOutputWithSurplus() public {
+        // Surplus: contract holds 110 of input but quote was for 100 -> output 99 * 110/100 = 108.9
+        uint256 balance = 110e18;
+        mockToken.mint(address(acrossApproveAndBridge), balance);
+
+        bytes memory data = _buildDepositCalldata(address(mockToken), 100e18, 99e18, "");
+
+        acrossApproveAndBridge.approveAndBridge(IERC20(mockToken), 100e18, 0, data);
+
+        assertEq(spokePool.lastInputAmount(), balance);
+        assertEq(spokePool.lastOutputAmount(), (99e18 * balance) / 100e18);
+    }
+
+    function test_approveAndBridge_ERC20_scalesOutputWhenBelowQuote() public {
+        uint256 balance = 90e18;
+        mockToken.mint(address(acrossApproveAndBridge), balance);
+
+        bytes memory data = _buildDepositCalldata(address(mockToken), 100e18, 99e18, "");
+
+        acrossApproveAndBridge.approveAndBridge(IERC20(mockToken), 50e18, 0, data);
+
+        assertEq(spokePool.lastInputAmount(), balance);
+        assertEq(spokePool.lastOutputAmount(), (99e18 * balance) / 100e18);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          NATIVE BRIDGE FLOW
+    //////////////////////////////////////////////////////////////*/
+    function test_approveAndBridge_native_forwardsValue() public {
+        uint256 balance = 5e18;
+        vm.deal(address(acrossApproveAndBridge), balance);
+
+        bytes memory data = _buildDepositCalldata(WETH, 5e18, 4.95e18, "");
+
+        acrossApproveAndBridge.approveAndBridge(IERC20(NATIVE_TOKEN_ADDRESS), 1e18, 0, data);
+
+        assertEq(spokePool.lastInputToken(), WETH);
+        assertEq(spokePool.lastInputAmount(), balance);
+        assertEq(spokePool.lastValue(), balance);
+    }
+
+    function test_approveAndBridge_native_forwardsExtraFee() public {
+        uint256 balance = 5e18;
+        uint256 extraFee = 0.05e18;
+        vm.deal(address(acrossApproveAndBridge), balance + extraFee);
+
+        bytes memory data = _buildDepositCalldata(WETH, 5e18, 4.95e18, "");
+
+        acrossApproveAndBridge.approveAndBridge(IERC20(NATIVE_TOKEN_ADDRESS), 1e18, extraFee, data);
+
+        assertEq(spokePool.lastInputAmount(), balance);
+        assertEq(spokePool.lastValue(), balance + extraFee);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            VALIDATION
+    //////////////////////////////////////////////////////////////*/
+    function test_approveAndBridge_revertsOnInsufficientBalance() public {
+        mockToken.mint(address(acrossApproveAndBridge), 10e18);
+
+        bytes memory data = _buildDepositCalldata(address(mockToken), 100e18, 99e18, "");
+
+        vm.expectRevert(ApproveAndBridge.MinAmountNotMet.selector);
+        acrossApproveAndBridge.approveAndBridge(IERC20(mockToken), 50e18, 0, data);
+    }
+
+    function test_approveAndBridge_revertsOnFailedDeposit() public {
+        AcrossApproveAndBridge failing = new AcrossApproveAndBridge(address(failingBridge));
+        mockToken.mint(address(failing), 100e18);
+
+        bytes memory data = _buildDepositCalldata(address(mockToken), 100e18, 99e18, "");
+
+        vm.expectRevert(AcrossApproveAndBridge.BridgeFailed.selector);
+        failing.approveAndBridge(IERC20(mockToken), 50e18, 0, data);
+    }
+
+    function test_approveAndBridge_revertsOnZeroOriginalInput() public {
+        mockToken.mint(address(acrossApproveAndBridge), 100e18);
+
+        bytes memory data = _buildDepositCalldata(address(mockToken), 0, 99e18, "");
+
+        vm.expectRevert(AcrossApproveAndBridge.InvalidInput.selector);
+        acrossApproveAndBridge.approveAndBridge(IERC20(mockToken), 50e18, 0, data);
+    }
+
+    function test_approveAndBridge_revertsOnTooShortCalldata() public {
+        mockToken.mint(address(acrossApproveAndBridge), 100e18);
+
+        bytes memory data = hex"7b939232"; // selector only
+
+        vm.expectRevert(AcrossApproveAndBridge.InvalidInput.selector);
+        acrossApproveAndBridge.approveAndBridge(IERC20(mockToken), 50e18, 0, data);
+    }
+
+    function test_approveAndBridge_revertsOnWrongSelector() public {
+        mockToken.mint(address(acrossApproveAndBridge), 100e18);
+
+        bytes memory data = _buildDepositCalldata(address(mockToken), 100e18, 99e18, "");
+        // Corrupt the selector
+        data[0] = 0xff;
+
+        vm.expectRevert(AcrossApproveAndBridge.InvalidInput.selector);
+        acrossApproveAndBridge.approveAndBridge(IERC20(mockToken), 50e18, 0, data);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              MESSAGES
+    //////////////////////////////////////////////////////////////*/
+    function test_approveAndBridge_passesMessageThrough() public {
+        mockToken.mint(address(acrossApproveAndBridge), 100e18);
+
+        bytes memory data = _buildDepositCalldata(address(mockToken), 100e18, 99e18, hex"deadbeefcafebabe");
+
+        acrossApproveAndBridge.approveAndBridge(IERC20(mockToken), 50e18, 0, data);
+
+        assertEq(spokePool.lastMessage(), hex"deadbeefcafebabe");
+    }
+}

--- a/test/mocks/MockAcrossSpokePool.sol
+++ b/test/mocks/MockAcrossSpokePool.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8;
+
+import {IAcrossSpokePoolV3} from "src/interface/IAcrossSpokePoolV3.sol";
+
+/// @dev Mock SpokePool that records the most recent `depositV3` call.
+/// @dev We capture the calldata via fallback and decode lazily, since a
+///      function taking 12 arguments + storing them all causes
+///      stack-too-deep with the legacy code generator.
+contract MockAcrossSpokePool {
+    address public lastDepositor;
+    address public lastRecipient;
+    address public lastInputToken;
+    address public lastOutputToken;
+    uint256 public lastInputAmount;
+    uint256 public lastOutputAmount;
+    uint256 public lastDestinationChainId;
+    address public lastExclusiveRelayer;
+    uint32 public lastQuoteTimestamp;
+    uint32 public lastFillDeadline;
+    uint32 public lastExclusivityDeadline;
+    bytes public lastMessage;
+    uint256 public lastValue;
+    uint256 public callCount;
+
+    fallback() external payable {
+        require(bytes4(msg.data[:4]) == IAcrossSpokePoolV3.depositV3.selector, "MockSpokePool: bad selector");
+        _recordStaticHead(msg.data[4:]);
+        _recordDynamicTail(msg.data[4:]);
+        lastValue = msg.value;
+        callCount += 1;
+    }
+
+    receive() external payable {}
+
+    /// @dev Decodes and stores the static-head fields (everything except `message`).
+    function _recordStaticHead(bytes calldata args) private {
+        (
+            address depositor,
+            address recipient,
+            address inputToken,
+            address outputToken,
+            uint256 inputAmount,
+            uint256 outputAmount,
+            uint256 destinationChainId,
+            address exclusiveRelayer
+        ) = abi.decode(args, (address, address, address, address, uint256, uint256, uint256, address));
+        lastDepositor = depositor;
+        lastRecipient = recipient;
+        lastInputToken = inputToken;
+        lastOutputToken = outputToken;
+        lastInputAmount = inputAmount;
+        lastOutputAmount = outputAmount;
+        lastDestinationChainId = destinationChainId;
+        lastExclusiveRelayer = exclusiveRelayer;
+    }
+
+    /// @dev Decodes and stores the deadlines and the dynamic `message`.
+    function _recordDynamicTail(bytes calldata args) private {
+        // Skip first 8 head slots (= 256 bytes) we already decoded.
+        bytes calldata rest = args[256:];
+        (uint32 quoteTimestamp, uint32 fillDeadline, uint32 exclusivityDeadline, bytes memory message) =
+            _decodeTail(args, rest);
+        lastQuoteTimestamp = quoteTimestamp;
+        lastFillDeadline = fillDeadline;
+        lastExclusivityDeadline = exclusivityDeadline;
+        lastMessage = message;
+    }
+
+    function _decodeTail(bytes calldata fullArgs, bytes calldata rest)
+        private
+        pure
+        returns (uint32, uint32, uint32, bytes memory)
+    {
+        (uint32 q, uint32 f, uint32 e, uint256 messageOffset) = abi.decode(rest, (uint32, uint32, uint32, uint256));
+        // messageOffset is relative to start of args (after selector). Read length + data.
+        bytes memory message = abi.decode(fullArgs[messageOffset:], (bytes));
+        return (q, f, e, message);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `AcrossApproveAndBridge` . This contract approves and deposits funds into Across v3 spoke pool.

It's meant to be called using a `delegateCall`, to the `approveAndBridge`. The contract will approve and deposit the full amount available in the calling contract (context, i.e. [cow-shed](https://github.com/cowdao-grants/cow-shed))

The contract makes sure the limit price in the original deposit params is respected, this means, it will add to the `outputAmount` the excess tokens respecting the original rate.

## Details
The contract accepts an encoded `depositV3` calldata payload and:
- Patches `inputAmount` (at fixed offset 132) to the actual balance held by the delegatecaller (e.g. cow-shed), so any surplus from the upstream swap is bridged.
- Scales `outputAmount` (at fixed offset 164) by `actualInput / originalInput`, so relayers honor the same exchange rate the user quoted.
- Forwards the call to the SpokePool with `msg.value = amount + nativeTokenExtraFee` for native deposits, or just `nativeTokenExtraFee` for ERC20 deposits.

`depositor` and `recipient` are passed through unchanged from the encoded calldata. Typically the caller sets `depositor` to the cow-shed (the address that holds the swap proceeds and would receive any refund on a slow-fill failure).

For native bridging the encoded calldata must specify the wrapped native token (e.g. WETH) as `inputToken` — the SpokePool wraps internally when called with `msg.value`.

## Test plan

- [x] `forge build`
- [x] `forge test --no-match-path "test/e2e/**"` — 72 tests pass (58 existing Bungee + 14 new Across)
